### PR TITLE
[IMP] Method check_if_test_already_succeeded

### DIFF
--- a/odoo_admin/addons/cicd/models/test_run_line.py
+++ b/odoo_admin/addons/cicd/models/test_run_line.py
@@ -54,6 +54,7 @@ class CicdTestRunLine(models.AbstractModel):
     )
     reused = fields.Boolean("Reused", readonly=True)
     started = fields.Datetime("Started", default=lambda self: fields.Datetime.now())
+    date_finished = fields.Datetime("Date Finished")
     effective_machine_id = fields.Many2one("cicd.machine", compute="_compute_machine")
     logfile_path = fields.Char("Logfilepath", compute="_compute_logfilepath")
     log = fields.Text("Log")
@@ -212,9 +213,9 @@ class CicdTestRunLine(models.AbstractModel):
                                 # e.g. robottests return state from run
                                 rec.state = "success"
                                 rec.exc_info = False
-                        end = arrow.get()
+                        rec.date_finished = fields.Datetime.now()
                         rec.duration = (
-                            end - arrow.get(rec.started or arrow.utcnow())
+                            arrow.get(rec.date_finished) - arrow.get(rec.started or arrow.utcnow())
                         ).total_seconds()
                         if rec.state == "success":
                             break

--- a/odoo_admin/addons/cicd/models/test_run_unittest.py
+++ b/odoo_admin/addons/cicd/models/test_run_unittest.py
@@ -313,13 +313,13 @@ class TestSettingsUnittest(models.Model):
         Compares the hash of the module with an existing
         previous run with same hash.
         """
-        res = self.env["cicd.test.run.line.unittest"].search_count(
+        tests = self.env["cicd.test.run.line.unittest"].search(
             [
                 ("run_id.branch_ids.repo_id", "=", testrun.branch_ids.repo_id.id),
                 ("reused", "=", False),
                 ("odoo_module", "=", odoo_module),
                 ("hash", "=", hash),
-                ("state", "=", "success"),
-            ]
+                ("state", "in", ["success", "failed"]),
+            ], order="date_finished desc, id desc", limit=1
         )
-        return bool(res)
+        return tests and tests.state == "success"


### PR DESCRIPTION
Adds a new field date_finished to the test.run.line
which is used by the method check_if_test_already_succeeded
the last unittest run state wouldn't be anymore success if one is test run state is in state success
now it would be the state of the last failed or success run (order by date_finished desc, id desc)